### PR TITLE
Fix TTR duration issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if err != nil {
 defer pool.Stop()
 
 // Reusable put parameters.
-putParams := &beanstalk.PutParams{1024, 0, 5}
+putParams := &beanstalk.PutParams{1024, 0, 5 * time.Second}
 
 // Insert a job containing "Hello World" in the beanstalk tube named "test".
 id, err := pool.Put("test", []byte("Hello World"), putParams)


### PR DESCRIPTION
@prep small bug in README, TTR in job is time.Duration, so TTR should be specified like this too.