### PR TITLE
Try a different producer in the pool on error

### DIFF
--- a/producer_pool.go
+++ b/producer_pool.go
@@ -68,7 +68,7 @@ func (pool *ProducerPool) Put(ctx context.Context, tube string, body []byte, par
 			continue
 		// If a producer returns any other error, log it and try the next one.
 		case err != nil:
-			pool.config.ErrorLog.Printf("ProducerPool unable to put job: %s", err)
+			pool.config.ErrorLog.Printf("ProducerPool could not put job: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
This PR makes a call to `Put()` on a `ProducerPool{}` try the other producers in the pool before returning an error, if the error is anything other than `ErrDisconnected`.