### PR TITLE
Add a Multiply configuration

### DIFF
--- a/beanstalk.go
+++ b/beanstalk.go
@@ -132,3 +132,14 @@ func keepConnected(handler ioHandler, conn *Conn, config Config, close chan stru
 		}
 	}()
 }
+
+// multiply a slice by the specified amount. This is used to multiply the
+// number of TCP client connections.
+func multiply(list []string, multiply int) []string {
+	var results []string
+	for i := 0; i < multiply; i++ {
+		results = append(results, list...)
+	}
+
+	return results
+}

--- a/beanstalk_test.go
+++ b/beanstalk_test.go
@@ -68,3 +68,27 @@ func TestParseURI(t *testing.T) {
 		}
 	})
 }
+
+func TestMultiply(t *testing.T) {
+	list := multiply([]string{"a", "b", "c"}, 3)
+	if len(list) != 9 {
+		t.Fatalf("Expected 9 items in the list")
+	}
+
+	for i, item := range list {
+		switch i % 3 {
+		case 0:
+			if item != "a" {
+				t.Fatalf("Expected a for item %d", i)
+			}
+		case 1:
+			if item != "b" {
+				t.Fatalf("Expected b for item %d", i)
+			}
+		case 2:
+			if item != "c" {
+				t.Fatalf("Expected c for item %d", i)
+			}
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -14,6 +14,11 @@ type Config struct {
 	// can be overridden by a context deadline if its value is lower.
 	// The default is to have no timeout.
 	ConnTimeout time.Duration
+	// Multiply the list of URIs specified to any producer pool or consumer pool.
+	// The effect of this is more TCP connections being set up to load balance
+	// traffic over.
+	// The default is to have 1.
+	Multiply int
 	// NumGoroutines is the number of goroutines that the Receive() method will
 	// spin up.
 	// The default is to spin up 1 goroutine.
@@ -41,6 +46,9 @@ type Config struct {
 }
 
 func (config Config) normalize() Config {
+	if config.Multiply < 1 {
+		config.Multiply = 1
+	}
 	if config.NumGoroutines < 1 {
 		config.NumGoroutines = 1
 	}

--- a/consumer_pool.go
+++ b/consumer_pool.go
@@ -24,7 +24,7 @@ func NewConsumerPool(uris []string, tubes []string, config Config) (*ConsumerPoo
 	config = config.normalize()
 
 	pool := &ConsumerPool{C: config.jobC, config: config, stop: make(chan struct{})}
-	for _, uri := range uris {
+	for _, uri := range multiply(uris, config.Multiply) {
 		consumer, err := NewConsumer(uri, tubes, config)
 		if err != nil {
 			pool.Stop()

--- a/producer_pool.go
+++ b/producer_pool.go
@@ -23,7 +23,7 @@ func NewProducerPool(uris []string, config Config) (*ProducerPool, error) {
 	config = config.normalize()
 
 	pool := &ProducerPool{config: config}
-	for _, URI := range uris {
+	for _, URI := range multiply(uris, config.Multiply) {
 		producer, err := NewProducer(URI, config)
 		if err != nil {
 			pool.Stop()


### PR DESCRIPTION
This PR adds a `Multiply` configuration that allows you to have the ConsumerPool and ProducerPool create more individual TCP client connections from the specified list of URIs.