### PR TITLE
Normalize Config{} before using it

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -47,6 +47,8 @@ func Dial(uri string, config Config) (*Conn, error) {
 		return nil, err
 	}
 
+	config = config.normalize()
+
 	// Dial into the beanstalk server.
 	var netConn net.Conn
 	if isTLS {
@@ -69,7 +71,7 @@ func Dial(uri string, config Config) (*Conn, error) {
 
 	return &Conn{
 		URI:    uri,
-		config: config.normalize(),
+		config: config,
 		conn:   netConn,
 		text:   textproto.NewConn(netConn),
 	}, nil

--- a/consumer.go
+++ b/consumer.go
@@ -23,10 +23,12 @@ func NewConsumer(uris []string, tubes []string, config Config) (*Consumer, error
 		return nil, err
 	}
 
+	config = config.normalize()
+
 	return &Consumer{
 		uris:     uris,
 		tubes:    tubes,
-		config:   config.normalize(),
+		config:   config,
 		reserveC: make(chan chan *Job, config.NumGoroutines),
 	}, nil
 }


### PR DESCRIPTION
This PR fixes a bug where `Config{}` wasn't normalized before being used in certain cases, which triggered a bug in the consumer that resulted in a non-buffered _reserve token channel_ causing a deadlock.