### PR TITLE
Add IgnoreURIValidation config flag to create consumer and producer without URI validation

### DIFF
--- a/beanstalk.go
+++ b/beanstalk.go
@@ -71,9 +71,9 @@ func includes(a []string, s string) bool {
 	return false
 }
 
-// validURIs returns an error if any of the specified URIs is invalid, or if
+// ValidURIs returns an error if any of the specified URIs is invalid, or if
 // the host names in the URIs could not be resolved.
-func validURIs(uris []string) error {
+func ValidURIs(uris []string) error {
 	if len(uris) == 0 {
 		return errors.New("no URIs specified")
 	}

--- a/config.go
+++ b/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	InfoFunc func(message string)
 	// ErrorFunc is called to log error messages.
 	ErrorFunc func(err error, message string)
+	// IgnoreURIValidation skips the step of calling ValidURIs() method during initialization
+	IgnoreURIValidation bool
 }
 
 func (config Config) normalize() Config {

--- a/consumer.go
+++ b/consumer.go
@@ -19,15 +19,12 @@ type Consumer struct {
 
 // NewConsumer returns a new Consumer or returns an error if the uris is not valid or empty.
 func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
-	if err := ValidURIs(uris); err != nil {
-		return nil, err
+	if !config.IgnoreURIValidation {
+		if err := ValidURIs(uris); err != nil {
+			return nil, err
+		}
 	}
 
-	return NewConsumerWithoutURIValidation(uris, tubes, config), nil
-}
-
-// NewConsumerWithoutURIValidation returns a new Consumer
-func NewConsumerWithoutURIValidation(uris, tubes []string, config Config) *Consumer {
 	config = config.normalize()
 
 	return &Consumer{
@@ -35,7 +32,7 @@ func NewConsumerWithoutURIValidation(uris, tubes []string, config Config) *Consu
 		tubes:    tubes,
 		config:   config,
 		reserveC: make(chan chan *Job, config.NumGoroutines),
-	}
+	}, nil
 }
 
 // Receive calls fn for each job it can reserve.

--- a/consumer.go
+++ b/consumer.go
@@ -17,7 +17,7 @@ type Consumer struct {
 	wg       sync.WaitGroup
 }
 
-// NewConsumer returns a new Consumer
+// NewConsumer returns a new Consumer.
 func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
 	if !config.IgnoreURIValidation {
 		if err := ValidURIs(uris); err != nil {

--- a/consumer.go
+++ b/consumer.go
@@ -17,12 +17,17 @@ type Consumer struct {
 	wg       sync.WaitGroup
 }
 
-// NewConsumer returns a new Consumer.
+// NewConsumer returns a new Consumer or returns an error if the uris is not valid or empty.
 func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
-	if err := validURIs(uris); err != nil {
+	if err := ValidURIs(uris); err != nil {
 		return nil, err
 	}
 
+	return NewConsumerWithoutURIValidation(uris, tubes, config), nil
+}
+
+// NewConsumerWithoutURIValidation returns a new Consumer
+func NewConsumerWithoutURIValidation(uris, tubes []string, config Config) *Consumer {
 	config = config.normalize()
 
 	return &Consumer{
@@ -30,7 +35,7 @@ func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
 		tubes:    tubes,
 		config:   config,
 		reserveC: make(chan chan *Job, config.NumGoroutines),
-	}, nil
+	}
 }
 
 // Receive calls fn for each job it can reserve.

--- a/consumer.go
+++ b/consumer.go
@@ -17,7 +17,7 @@ type Consumer struct {
 	wg       sync.WaitGroup
 }
 
-// NewConsumer returns a new Consumer or returns an error if the uris is not valid or empty.
+// NewConsumer returns a new Consumer
 func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
 	if !config.IgnoreURIValidation {
 		if err := ValidURIs(uris); err != nil {

--- a/producer.go
+++ b/producer.go
@@ -18,7 +18,7 @@ type Producer struct {
 	mu        sync.RWMutex
 }
 
-// NewProducer returns a new Producer
+// NewProducer returns a new Producer.
 func NewProducer(uris []string, config Config) (*Producer, error) {
 	if !config.IgnoreURIValidation {
 		if err := ValidURIs(uris); err != nil {

--- a/producer.go
+++ b/producer.go
@@ -18,7 +18,7 @@ type Producer struct {
 	mu        sync.RWMutex
 }
 
-// NewProducer returns a new Producer or returns an error if the uris is not valid or empty.
+// NewProducer returns a new Producer
 func NewProducer(uris []string, config Config) (*Producer, error) {
 	if !config.IgnoreURIValidation {
 		if err := ValidURIs(uris); err != nil {

--- a/producer.go
+++ b/producer.go
@@ -20,15 +20,11 @@ type Producer struct {
 
 // NewProducer returns a new Producer or returns an error if the uris is not valid or empty.
 func NewProducer(uris []string, config Config) (*Producer, error) {
-	if err := ValidURIs(uris); err != nil {
-		return nil, err
+	if !config.IgnoreURIValidation {
+		if err := ValidURIs(uris); err != nil {
+			return nil, err
+		}
 	}
-
-	return NewProducerWithoutURIValidation(uris, config), nil
-}
-
-// NewProducerWithoutURIValidation returns a new Producer.
-func NewProducerWithoutURIValidation(uris []string, config Config) *Producer {
 
 	// Create a context that can be cancelled to stop the producers.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -44,7 +40,7 @@ func NewProducerWithoutURIValidation(uris []string, config Config) *Producer {
 		pool.producers = append(pool.producers, producer)
 	}
 
-	return pool
+	return pool, nil
 }
 
 // Stop this producer.

--- a/producer.go
+++ b/producer.go
@@ -18,11 +18,17 @@ type Producer struct {
 	mu        sync.RWMutex
 }
 
-// NewProducer returns a new Producer.
+// NewProducer returns a new Producer or returns an error if the uris is not valid or empty.
 func NewProducer(uris []string, config Config) (*Producer, error) {
-	if err := validURIs(uris); err != nil {
+	if err := ValidURIs(uris); err != nil {
 		return nil, err
 	}
+
+	return NewProducerWithoutURIValidation(uris, config), nil
+}
+
+// NewProducerWithoutURIValidation returns a new Producer.
+func NewProducerWithoutURIValidation(uris []string, config Config) *Producer {
 
 	// Create a context that can be cancelled to stop the producers.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -38,7 +44,7 @@ func NewProducer(uris []string, config Config) (*Producer, error) {
 		pool.producers = append(pool.producers, producer)
 	}
 
-	return pool, nil
+	return pool
 }
 
 // Stop this producer.

--- a/producer_test.go
+++ b/producer_test.go
@@ -61,6 +61,17 @@ func TestProducer(t *testing.T) {
 				t.Fatalf("Producer was unable to connect")
 			}
 		})
+
+		// Test if a producer works when IgnoreURIValidation is set true and URIs are invalid
+		// connection.
+		t.Run("IgnoreURIValidation", func(t *testing.T) {
+			p, err := NewProducer([]string{"test-uri-1", "test-uri-2"}, Config{IgnoreURIValidation: true})
+			if err != nil {
+				t.Fatalf("Unable to create a new producer: %s", err)
+			}
+			defer p.Stop()
+			time.Sleep(10 * time.Millisecond)
+		})
 	})
 
 	ctx := context.Background()

--- a/producer_test.go
+++ b/producer_test.go
@@ -70,7 +70,6 @@ func TestProducer(t *testing.T) {
 				t.Fatalf("Unable to create a new producer: %s", err)
 			}
 			defer p.Stop()
-			time.Sleep(10 * time.Millisecond)
 		})
 	})
 


### PR DESCRIPTION
In some cases, the caller side would like to create producers and consumers even though there is a URI validation issue. Because URI could be temporarily unreachable. Instead of not creating producer and consumer, we can continue to redial based on `reconnecttimeout` value. `IgnoreURIValidation` is added for this purpose

Also lets the caller validate URI's by making `ValidURIs` method publicly reachable.