### PR TITLE
Export Delete() on Conn{}

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -223,11 +223,12 @@ func (conn *Conn) bury(ctx context.Context, job *Job, priority uint32) error {
 	return err
 }
 
-func (conn *Conn) delete(ctx context.Context, job *Job) error {
-	ctx, span := trace.StartSpan(ctx, "github.com/prep/beanstalk/Conn.delete")
+// Delete the job with the specified ID.
+func (conn *Conn) Delete(ctx context.Context, id uint64) error {
+	ctx, span := trace.StartSpan(ctx, "github.com/prep/beanstalk/Conn.Delete")
 	defer span.End()
 
-	_, _, err := conn.lcommand(ctx, "delete %d", job.ID)
+	_, _, err := conn.lcommand(ctx, "delete %d", id)
 	return err
 }
 
@@ -269,15 +270,6 @@ func (conn *Conn) kick(ctx context.Context, job *Job) error {
 
 	if job == nil {
 		return ErrNotFound
-	}
-
-	// If the tube is different than the last time, switch tubes.
-	if job.Stats.Tube != conn.lastTube {
-		if _, _, err := conn.command(ctx, "use %s", job.Stats.Tube); err != nil {
-			return err
-		}
-
-		conn.lastTube = job.Stats.Tube
 	}
 
 	_, _, err := conn.lcommand(ctx, "kick-job %d", job.ID)

--- a/conn_test.go
+++ b/conn_test.go
@@ -193,7 +193,7 @@ func TestConn(t *testing.T) {
 	})
 
 	// delete a job.
-	t.Run("delete", func(t *testing.T) {
+	t.Run("Delete", func(t *testing.T) {
 		server.HandleFunc(func(line Line) string {
 			switch {
 			case line.At(1, "delete 3"):
@@ -205,7 +205,7 @@ func TestConn(t *testing.T) {
 			return ""
 		})
 
-		if err := conn.delete(ctx, &Job{ID: 3}); err != nil {
+		if err := conn.Delete(ctx, 3); err != nil {
 			t.Fatalf("Error deleting job: %s", err)
 		}
 
@@ -222,7 +222,7 @@ func TestConn(t *testing.T) {
 				return ""
 			})
 
-			err := conn.delete(ctx, &Job{ID: 4})
+			err := conn.Delete(ctx, 4)
 			switch {
 			case errors.Is(err, ErrNotFound):
 			case err != nil:
@@ -356,8 +356,7 @@ func TestConn(t *testing.T) {
 		})
 
 		err := conn.release(ctx, &Job{ID: 8}, 12, 20*time.Second)
-		switch {
-		case err != nil:
+		if err != nil {
 			t.Fatalf("Error releasing job: %s", err)
 		}
 

--- a/job.go
+++ b/job.go
@@ -60,7 +60,7 @@ func (job *Job) Delete(ctx context.Context) error {
 		return ErrJobFinished
 	}
 
-	err := job.conn.delete(ctx, job)
+	err := job.conn.Delete(ctx, job.ID)
 	job.conn = nil
 	return err
 }


### PR DESCRIPTION
At the request of #20, export the `Delete()` method on `Conn{}` so that jobs can be deleted by ID if they are being tracked outside of the regular beanstalk flow.