### PR TITLE
Add support for Unix Domain Socket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ config := beanstalk.Config{
 
 ### URIs
 
-NewProducer, NewConsumer and Dial take a URI or a list of URIs as their first argument, who can be described in various formats. In the above examples the beanstalk server was referenced by the host:port notation. This package also supports URI formats like beanstalk:// for a plaintext connection, and beanstalks:// or tls:// for encrypted connections.
+NewProducer, NewConsumer and Dial take a URI or a list of URIs as their first argument, who can be described in various formats. In the above examples the beanstalk server was referenced by the host:port notation. This package also supports URI formats like beanstalk:// for a plaintext connection, and beanstalks:// or tls:// for encrypted connections, and unix:// for Unix Domain Socket connections.
 
 In the case of encrypted connections, if no port has been specified it will default to port 11400 as opposed to the default 11300 port.
 

--- a/beanstalk.go
+++ b/beanstalk.go
@@ -10,54 +10,70 @@ import (
 	"time"
 )
 
+type uriType string
+
+const (
+	uriTCPType uriType = "tcp"
+	uriTLSType uriType = "tls"
+	uriUDSType uriType = "unix"
+)
+
 // ParseURI returns the socket of the specified URI and if the connection is
 // supposed to be a TLS or plaintext connection. Valid URI schemes are:
 //
 //		beanstalk://host:port
 //		beanstalks://host:port
 //		tls://host:port
+//              unix://path
 //
 // Where both the beanstalks and tls scheme mean the same thing. Alternatively,
 // it is also possibly to just specify the host:port combo which is assumed to
 // be a plaintext connection.
-func ParseURI(uri string) (string, bool, error) {
-	var host string
-	var isTLS bool
+func ParseURI(uri string) (string, uriType, error) {
+	address := uri
+	uriType := uriTCPType
 
 	if strings.Contains(uri, "://") {
 		url, err := url.Parse(uri)
 		if err != nil {
-			return "", false, err
+			return "", uriType, err
 		}
 
 		// Determine the protocol scheme of the URI.
 		switch strings.ToLower(url.Scheme) {
 		case "beanstalk":
+			uriType = uriTCPType
+			address = url.Host
 		case "beanstalks", "tls":
-			isTLS = true
+			uriType = uriTLSType
+			address = url.Host
+		case "unix":
+			uriType = uriUDSType
+			address = url.Path
 		default:
-			return "", false, fmt.Errorf("%s: unknown beanstalk URI scheme", url.Scheme)
+			return "", uriType, fmt.Errorf("%s: unknown beanstalk URI scheme", url.Scheme)
 		}
 
-		host = url.Host
-	} else {
-		host = uri
+	}
+
+	if uriType == uriUDSType {
+		return address, uriType, nil
 	}
 
 	// Validate the resulting host:port combo.
-	_, _, err := net.SplitHostPort(host)
+	_, _, err := net.SplitHostPort(address)
 	switch {
 	case err != nil && strings.Contains(err.Error(), "missing port in address"):
-		if isTLS {
-			host += ":11400"
+		if uriType == uriTLSType {
+			address += ":11400"
 		} else {
-			host += ":11300"
+			address += ":11300"
 		}
 	case err != nil:
-		return "", false, err
+		return "", uriType, err
 	}
 
-	return host, isTLS, nil
+	return address, uriType, nil
 }
 
 // includes returns true if s is contained in a.

--- a/beanstalk.go
+++ b/beanstalk.go
@@ -18,7 +18,7 @@ const (
 	uriUDSType uriType = "unix"
 )
 
-// ParseURI returns the socket of the specified URI and if the connection is
+// parseURI returns the socket of the specified URI and if the connection is
 // supposed to be a TLS or plaintext connection. Valid URI schemes are:
 //
 //		beanstalk://host:port
@@ -29,7 +29,7 @@ const (
 // Where both the beanstalks and tls scheme mean the same thing. Alternatively,
 // it is also possibly to just specify the host:port combo which is assumed to
 // be a plaintext connection.
-func ParseURI(uri string) (string, uriType, error) {
+func parseURI(uri string) (string, uriType, error) {
 	address := uri
 	uriType := uriTCPType
 
@@ -95,7 +95,7 @@ func ValidURIs(uris []string) error {
 	}
 
 	for _, uri := range uris {
-		hostport, _, err := ParseURI(uri)
+		hostport, _, err := parseURI(uri)
 		if err != nil {
 			return err
 		}

--- a/beanstalk_test.go
+++ b/beanstalk_test.go
@@ -4,41 +4,60 @@ import "testing"
 
 func TestParseURI(t *testing.T) {
 	t.Run("WithValidSchemes", func(t *testing.T) {
-		for _, scheme := range []string{"beanstalk", "beanstalks", "tls"} {
-			uri := scheme + "://localhost:12345"
+		cases := []struct {
+			uri     string
+			uriType uriType
+			address string
+		}{
+			{
+				uri:     "beanstalk://localhost:12345",
+				uriType: uriTCPType,
+				address: "localhost:12345",
+			},
+			{
+				uri:     "beanstalks://localhost:12345",
+				uriType: uriTLSType,
+				address: "localhost:12345",
+			},
+			{
+				uri:     "tls://localhost:12345",
+				uriType: uriTLSType,
+				address: "localhost:12345",
+			},
+			{
+				uri:     "unix:///tmp/beanstalkd.sock",
+				uriType: uriUDSType,
+				address: "/tmp/beanstalkd.sock",
+			},
+		}
 
-			host, useTLS, err := ParseURI(uri)
-			switch {
-			case err != nil:
-				t.Errorf("Unable to parse URI: %s", uri)
-			case host != "localhost:12345":
-				t.Errorf("Unexpected host: %s", host)
-			}
+		for _, c := range cases {
+			t.Run(string(c.uriType), func(t *testing.T) {
+				address, uriType, err := ParseURI(c.uri)
+				if err != nil {
+					t.Errorf("Unable to parse URI: %s", c.uri)
+				}
 
-			switch scheme {
-			case "beanstalk":
-				if useTLS {
-					t.Errorf("%s: scheme shouldn't support TLS", scheme)
+				if address != c.address {
+					t.Errorf("Got address: %q, expected: %q", address, c.address)
 				}
-			case "beanstalks", "tls":
-				if !useTLS {
-					t.Errorf("%s: scheme should support TLS", scheme)
+
+				if uriType != c.uriType {
+					t.Errorf("Got URI type: %q, expected: %q", uriType, c.uriType)
 				}
-			default:
-				t.Fatalf("%s: unknown scheme", scheme)
-			}
+			})
 		}
 	})
 
 	t.Run("WithMissingScheme", func(t *testing.T) {
-		host, useTLS, err := ParseURI("localhost:11300")
+		host, uriType, err := ParseURI("localhost:11300")
 		switch {
 		case err != nil:
 			t.Fatalf("Error parsing URI without scheme: %s", err)
 		case host != "localhost:11300":
 			t.Errorf("Unexpected host: %s", host)
-		case useTLS:
-			t.Error("Unexpected TLS to be set")
+		case uriType != uriTCPType:
+			t.Errorf("Got uri type: %q, expected: %q", uriType, uriTCPType)
 		}
 	})
 

--- a/beanstalk_test.go
+++ b/beanstalk_test.go
@@ -33,7 +33,7 @@ func TestParseURI(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(string(c.uriType), func(t *testing.T) {
-				address, uriType, err := ParseURI(c.uri)
+				address, uriType, err := parseURI(c.uri)
 				if err != nil {
 					t.Errorf("Unable to parse URI: %s", c.uri)
 				}
@@ -50,7 +50,7 @@ func TestParseURI(t *testing.T) {
 	})
 
 	t.Run("WithMissingScheme", func(t *testing.T) {
-		host, uriType, err := ParseURI("localhost:11300")
+		host, uriType, err := parseURI("localhost:11300")
 		switch {
 		case err != nil:
 			t.Fatalf("Error parsing URI without scheme: %s", err)
@@ -62,7 +62,7 @@ func TestParseURI(t *testing.T) {
 	})
 
 	t.Run("WithMissingPort", func(t *testing.T) {
-		host, _, err := ParseURI("beanstalk://localhost")
+		host, _, err := parseURI("beanstalk://localhost")
 		switch {
 		case err != nil:
 			t.Fatalf("Error parsing URI without port")
@@ -72,7 +72,7 @@ func TestParseURI(t *testing.T) {
 	})
 
 	t.Run("WithMissingTLSPort", func(t *testing.T) {
-		host, _, err := ParseURI("beanstalks://localhost")
+		host, _, err := parseURI("beanstalks://localhost")
 		switch {
 		case err != nil:
 			t.Fatalf("Error parsing URI without port")
@@ -82,7 +82,7 @@ func TestParseURI(t *testing.T) {
 	})
 
 	t.Run("WithInvalidScheme", func(t *testing.T) {
-		if _, _, err := ParseURI("foo://localhost:12345"); err == nil {
+		if _, _, err := parseURI("foo://localhost:12345"); err == nil {
 			t.Fatal("Expected an error, but got nothing")
 		}
 	})

--- a/conn.go
+++ b/conn.go
@@ -42,7 +42,7 @@ type Conn struct {
 
 // Dial into a beanstalk server.
 func Dial(uri string, config Config) (*Conn, error) {
-	socket, uriType, err := ParseURI(uri)
+	socket, uriType, err := parseURI(uri)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds support for `unix` schema in URIs and addresses https://github.com/prep/beanstalk/issues/23