### PR TITLE
Update ValidURIs function to accept UDS

### DIFF
--- a/beanstalk.go
+++ b/beanstalk.go
@@ -95,12 +95,16 @@ func ValidURIs(uris []string) error {
 	}
 
 	for _, uri := range uris {
-		hostport, _, err := parseURI(uri)
+		address, uriType, err := parseURI(uri)
 		if err != nil {
 			return err
 		}
 
-		host, _, err := net.SplitHostPort(hostport)
+		if uriType == uriUDSType {
+			continue
+		}
+
+		host, _, err := net.SplitHostPort(address)
 		if err != nil {
 			return err
 		}

--- a/beanstalk_test.go
+++ b/beanstalk_test.go
@@ -2,6 +2,39 @@ package beanstalk
 
 import "testing"
 
+func TestValidURIs(t *testing.T) {
+	cases := map[string]struct {
+		uris     []string
+		expected bool
+	}{
+		"no address": {
+			uris:     []string{},
+			expected: false,
+		},
+		"unix socket": {
+			uris:     []string{"unix:///tmp/beanstalk.sock"},
+			expected: true,
+		},
+		"tcp socket": {
+			uris:     []string{"tls://localhost:12345"},
+			expected: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := true
+			if err := ValidURIs(c.uris); err != nil {
+				actual = false
+			}
+
+			if actual != c.expected {
+				t.Errorf("Got validity: %v, expected: %v", actual, c.expected)
+			}
+		})
+	}
+}
+
 func TestParseURI(t *testing.T) {
 	t.Run("WithValidSchemes", func(t *testing.T) {
 		cases := []struct {


### PR DESCRIPTION
This PR updates ValidURIs check to handle UDS addresses differently from TCP socket addresses.
One distinct difference is that UDS does not require a port number. I am adding a test for this function.