### PR TITLE
Test uris connectable

### DIFF
--- a/beanstalk.go
+++ b/beanstalk.go
@@ -113,6 +113,23 @@ func ValidURIs(uris []string) error {
 	return nil
 }
 
+// DialURIs return an error if any of the specified URIs is un connectable
+func DialURIs(uris []string, config Config) error {
+	if len(uris) == 0 {
+		return errors.New("no URIs specified")
+	}
+	for _, uri := range uris {
+		connection, err := Dial(uri, config)
+		if err != nil {
+			return err
+		} else {
+			// close the connection if test ok
+			_ = connection.Close()
+		}
+	}
+	return nil
+}
+
 type connHandler struct {
 	// setup the connection after it has been established. This is used by
 	// the consumer to watch the proper tubes.

--- a/config.go
+++ b/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	ErrorFunc func(err error, message string)
 	// IgnoreURIValidation skips the step of calling ValidURIs() method during initialization
 	IgnoreURIValidation bool
+	// SkipTryURIConnectable do not test the URI is connectable before NewProducer
+	SkipTryURIConnectable bool
 }
 
 func (config Config) normalize() Config {

--- a/consumer.go
+++ b/consumer.go
@@ -25,6 +25,12 @@ func NewConsumer(uris, tubes []string, config Config) (*Consumer, error) {
 		}
 	}
 
+	if !config.SkipTryURIConnectable {
+		if err := DialURIs(uris, config); err != nil {
+			return nil, err
+		}
+	}
+
 	config = config.normalize()
 
 	return &Consumer{

--- a/producer.go
+++ b/producer.go
@@ -26,6 +26,12 @@ func NewProducer(uris []string, config Config) (*Producer, error) {
 		}
 	}
 
+	if !config.SkipTryURIConnectable {
+		if err := DialURIs(uris, config); err != nil {
+			return nil, err
+		}
+	}
+
 	// Create a context that can be cancelled to stop the producers.
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/34824811/192679725-5af5b02d-4646-4a2a-b39f-7a5c4ca7ebf2.png)

because `maintainConn` use the goroutine to get connection pool. so use the  `time.sleep` to confirm the connected is not reliable if the network delay

some project will check all connection such as mysql or redis connection is ok before start service

so i add a dial check(default open) before the `NewProducer` and `NewConsumer` to confirm the uris is connectable
